### PR TITLE
Change node creation callbacks

### DIFF
--- a/src/backend/rust.rs
+++ b/src/backend/rust.rs
@@ -2,7 +2,7 @@ use crate::frontend::ast::*;
 use crate::frontend::parser::{Cst, NodeRef};
 use crate::frontend::sema::*;
 use crate::VERSION;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Write;
 use std::path::Path;
 
@@ -89,7 +89,7 @@ impl RustOutput {
         let mut parser_file = std::fs::File::create(path)?;
         let skeleton = include_str!("../skeleton/parser.rs");
         parser_file.write_all(skeleton.as_bytes())?;
-        Self::output_parser_callbacks(&mut parser_file, sema, false)
+        Self::output_parser_callbacks(&mut parser_file, sema, false, BTreeMap::default())
     }
 
     fn output_lexer(cst: &Cst, file: File, path: &Path) -> std::io::Result<()> {
@@ -121,16 +121,15 @@ impl RustOutput {
         output: &mut std::fs::File,
         sema: &SemanticData,
         is_trait: bool,
+        rule_names: BTreeMap<&str, bool>,
     ) -> std::io::Result<()> {
         output.write_all(if is_trait {
-            b"trait ParserCallbacks {\
+            b"#[allow(clippy::ptr_arg)]\
+            \ntrait ParserCallbacks {\
             \n    /// Called at the start of the parse to generate all tokens and corresponding spans.\
             \n    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>);\
-            \n    /// Called when a new diagnostic is created.\
-            \n    fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic;\
-            \n    /// Called when a new syntax tree node is created.\
-            \n    #[allow(clippy::ptr_arg)]\
-            \n    fn create_node(&mut self, _rule: Rule, _node_ref: NodeRef, _diags: &mut Vec<Diagnostic>) {}\n"
+            \n    /// Called when diagnostic is created.\
+            \n    fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic;\n\n"
         } else {
             b"impl<'a> ParserCallbacks for Parser<'a> {\
             \n    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {\
@@ -142,12 +141,40 @@ impl RustOutput {
             \n            .with_labels(vec![Label::primary((), span)])\
             \n    }\n"
         })?;
+        if is_trait {
+            for (rule_name, _) in rule_names.iter() {
+                output.write_all(
+                    format!(
+                        "    /// Called when `{rule_name}` node is created.\
+                       \n    fn create_node_{rule_name}(&mut self, _node_ref: NodeRef, _diags: &mut Vec<Diagnostic>) {{}}\n"
+                    ).as_bytes()
+                )?;
+            }
+            output.write_all(b"\n")?;
+            for (rule_name, in_choice) in rule_names {
+                if in_choice {
+                    output.write_all(
+                        format!(
+                            "    /// Called when `{rule_name}` node is deleted during backtracking.\
+                           \n    fn delete_node_{rule_name}(&mut self, _node_ref: NodeRef, _diags: &mut Vec<Diagnostic>) {{}}\n"
+                        ).as_bytes()
+                    )?;
+                }
+            }
+            output.write_all(b"\n")?;
+        }
         let mut predicates = HashSet::new();
         for (rule, num) in sema.predicates.values() {
             if predicates.contains(&(rule, num)) {
                 continue;
             }
             predicates.insert((rule, num));
+            if is_trait {
+                output.write_all(
+                    format!("    /// Called when semantic predicate `?{num}` in rule `{rule}` is visited.\n")
+                        .as_bytes(),
+                )?;
+            }
             output.write_all(
                 format!(
                     "    fn predicate_{rule}_{num}(&self) -> bool{}\n",
@@ -166,6 +193,12 @@ impl RustOutput {
                 continue;
             }
             actions.insert((rule, num));
+            if is_trait {
+                output.write_all(
+                    format!("    /// Called when semantic action `#{num}` in rule `{rule}` is visited.\n")
+                        .as_bytes(),
+                )?;
+            }
             output.write_all(
                 format!(
                     "    fn action_{rule}_{num}(&mut self, diags: &mut Vec<Diagnostic>){}\n",
@@ -184,6 +217,12 @@ impl RustOutput {
                 continue;
             }
             assertions.insert((rule, num));
+            if is_trait {
+                output.write_all(
+                    format!("    /// Called when semantic assertion `!{num}` in rule `{rule}` is visited.\n")
+                        .as_bytes(),
+                )?;
+            }
             output.write_all(
                 format!(
                     "    fn assertion_{rule}_{num}(&self) -> Option<Diagnostic>{}\n",
@@ -228,17 +267,23 @@ impl RustOutput {
         assign_lhs: bool,
         parser_name: &str,
     ) -> std::io::Result<()> {
-        let lhs = if assign_lhs { "lhs = " } else { "" };
+        let lhs = if assign_lhs { "lhs = closed;" } else { "" };
         if has_rule_rename {
             output.write_all(
-                format!("{lhs}{parser_name}.close(m, node_kind, diags);\n")
-                    .indent(level)
-                    .as_bytes(),
+                format!(
+                    "let closed = {parser_name}.cst.close(m, node_kind);\
+                   \n{parser_name}.create_node(node_kind, NodeRef(closed.0), diags);\
+                   \n{lhs}\n"
+                )
+                .indent(level)
+                .as_bytes(),
             )
         } else {
             output.write_all(
                 format!(
-                    "{lhs}{parser_name}.close(m, Rule::{}, diags);\n",
+                    "let closed = {parser_name}.cst.close(m, Rule::{});\
+                   \n{parser_name}.create_node_{name}(NodeRef(closed.0), diags);\
+                   \n{lhs}\n",
                     Self::snake_to_pascal_case(name),
                 )
                 .indent(level)
@@ -301,7 +346,8 @@ impl RustOutput {
                 \n                }\
                 \n                self.pos += 1;\
                 \n            }\
-                \n            self.close(error_tree, Rule::Error, diags);\
+                \n            self.cst.close(error_tree, Rule::Error);\
+                \n            self.create_node_error(NodeRef(error_tree.0), diags);\
                 \n        }\n",
             )?;
         }
@@ -791,7 +837,7 @@ impl RustOutput {
                             .as_bytes(),
                     )?;
                     output.write_all(
-                        format!("{parser_name}.set_state(&state);\n")
+                        format!("{parser_name}.set_state(&state, diags);\n")
                             .indent(level + 1)
                             .as_bytes(),
                     )?;
@@ -1163,7 +1209,8 @@ impl RustOutput {
                 output.write_all(
                     format!(
                         "let open_node = {parser_name}.cst.open_before({mark});\
-                        \n{parser_name}.close(open_node, Rule::{}, diags);\n",
+                       \n{parser_name}.cst.close(open_node, Rule::{});\
+                       \n{parser_name}.create_node_{node_name}(NodeRef({mark}.0), diags);\n",
                         Self::snake_to_pascal_case(node_name)
                     )
                     .indent(level)
@@ -1213,34 +1260,68 @@ impl RustOutput {
                 .map_or(name, |(sym, _)| &sym[1..sym.len() - 1]);
             token_symbols.insert(name, sym);
         }
+        let contains_ordered_choice = !sema.used_in_ordered_choice.is_empty();
+        let mut rule_names = BTreeMap::from_iter([("error", contains_ordered_choice)]);
+        for rule in file.rule_decls(cst) {
+            let in_choice = sema.used_in_ordered_choice.contains(&rule.syntax());
+            rule_names
+                .entry(rule.name(cst).unwrap().0)
+                .and_modify(|val| *val |= in_choice)
+                .or_insert(in_choice);
+        }
+        for (rule_name, node_refs) in sema.rule_bindings.iter() {
+            let in_choice = node_refs.iter().fold(false, |acc, node_ref| {
+                acc | sema.used_in_ordered_choice.contains(node_ref)
+            });
+            rule_names
+                .entry(rule_name)
+                .and_modify(|val| *val |= in_choice)
+                .or_insert(in_choice);
+        }
         let mut rules = "".to_string();
         let mut rules_fmt = "".to_string();
-        let mut rule_names = HashSet::new();
-        for rule in file.rule_decls(cst) {
-            let rule_name = rule.name(cst).unwrap().0;
-            rule_names.insert(rule_name);
+        let mut rules_create = "".to_string();
+        let mut rules_delete = if contains_ordered_choice {
+            "match _rule {".to_string()
+        } else {
+            "".to_string()
+        };
+        let mut delete_covered = true;
+        for (rule_name, in_choice) in rule_names.iter() {
+            let pascal_case_name = &Self::snake_to_pascal_case(rule_name);
+
             rules += "\n    ";
-            rules += &Self::snake_to_pascal_case(rule_name);
+            rules += pascal_case_name;
             rules += ",";
+
             rules_fmt += "\n    Rule::";
-            rules_fmt += &Self::snake_to_pascal_case(rule_name);
+            rules_fmt += pascal_case_name;
             rules_fmt += " => write!(f, \"";
             rules_fmt += rule_name;
             rules_fmt += "\"),";
-        }
-        for rule_name in sema.rule_bindings.iter() {
-            if rule_names.contains(rule_name) {
-                continue;
+
+            rules_create += "\n            Rule::";
+            rules_create += pascal_case_name;
+            rules_create += " => self.create_node_";
+            rules_create += rule_name;
+            rules_create += "(node_ref, diags),";
+
+            delete_covered &= *in_choice;
+            if *in_choice {
+                rules_delete += "\n            Rule::";
+                rules_delete += pascal_case_name;
+                rules_delete += " => self.delete_node_";
+                rules_delete += rule_name;
+                rules_delete += "(_node_ref, _diags),";
             }
-            rules += "\n    ";
-            rules += &Self::snake_to_pascal_case(rule_name);
-            rules += ",";
-            rules_fmt += "\n    Rule::";
-            rules_fmt += &Self::snake_to_pascal_case(rule_name);
-            rules_fmt += " => write!(f, \"";
-            rules_fmt += rule_name;
-            rules_fmt += "\"),";
         }
+        if contains_ordered_choice {
+            if !delete_covered {
+                rules_delete += "\n            _ => {}";
+            }
+            rules_delete += "\n         }"
+        }
+
         let mut skip = "".to_string();
         for token in sema.skipped.iter() {
             skip += " | Token::";
@@ -1254,6 +1335,8 @@ impl RustOutput {
                 skip,
                 sema.start.unwrap().name(cst).unwrap().0,
                 rules_fmt,
+                rules_create,
+                rules_delete,
             )
             .as_bytes(),
         )?;
@@ -1262,6 +1345,6 @@ impl RustOutput {
         }
         output.write_all(b"}\n\n")?;
 
-        Self::output_parser_callbacks(output, sema, true)
+        Self::output_parser_callbacks(output, sema, true, rule_names)
     }
 }

--- a/src/backend/rust.rs
+++ b/src/backend/rust.rs
@@ -156,8 +156,9 @@ impl RustOutput {
                     output.write_all(
                         format!(
                             "    /// Called when `{rule_name}` node is deleted during backtracking.\
-                           \n    fn delete_node_{rule_name}(&mut self, _node_ref: NodeRef, _diags: &mut Vec<Diagnostic>) {{}}\n"
-                        ).as_bytes()
+                           \n    fn delete_node_{rule_name}(&mut self, _node_ref: NodeRef) {{}}\n"
+                        )
+                        .as_bytes(),
                     )?;
                 }
             }
@@ -797,7 +798,7 @@ impl RustOutput {
                 )?;
                 output.write_all("'ordered_choice: {\n".indent(level).as_bytes())?;
                 output.write_all(
-                    format!("let state = {parser_name}.get_state();\n")
+                    format!("let state = {parser_name}.get_state(diags);\n")
                         .indent(level + 1)
                         .as_bytes(),
                 )?;
@@ -1312,7 +1313,7 @@ impl RustOutput {
                 rules_delete += pascal_case_name;
                 rules_delete += " => self.delete_node_";
                 rules_delete += rule_name;
-                rules_delete += "(_node_ref, _diags),";
+                rules_delete += "(_node_ref),";
             }
         }
         if contains_ordered_choice {

--- a/src/frontend/diag.rs
+++ b/src/frontend/diag.rs
@@ -404,7 +404,8 @@ impl LanguageErrors for Diagnostic {
             .with_message("semantic action could be used inside of ordered choice")
             .with_labels(vec![Label::primary((), span.clone())])
             .with_notes(vec![
-                "note: this is not allowed to prevent side effects where backtracking is possible".to_string(),
+                "note: this is not allowed to prevent side effects where backtracking is possible"
+                    .to_string(),
             ])
     }
 }

--- a/src/frontend/generated.rs
+++ b/src/frontend/generated.rs
@@ -398,6 +398,7 @@ struct ParserState {
     pos: usize,
     current: Token,
     truncation_mark: MarkTruncation,
+    diag_count: usize,
 }
 pub struct Parser<'a> {
     cst: Cst<'a>,
@@ -504,19 +505,21 @@ impl<'a> Parser<'a> {
             .get(self.pos)
             .map_or(self.max_offset..self.max_offset, |span| span.clone())
     }
-    fn get_state(&self) -> ParserState {
+    fn get_state(&self, diags: &[Diagnostic]) -> ParserState {
         ParserState {
             pos: self.pos,
             current: self.current,
             truncation_mark: self.cst.mark_truncation(),
+            diag_count: diags.len(),
         }
     }
     fn set_state(&mut self, state: &ParserState, diags: &mut Vec<Diagnostic>) {
         self.pos = state.pos;
         self.current = state.current;
+        diags.truncate(state.diag_count);
         for i in state.truncation_mark.node_count..self.cst.nodes.len() {
             if let Node::Rule(rule, _) = self.cst.nodes[i] {
-                self.delete_node(rule, NodeRef(i), diags);
+                self.delete_node(rule, NodeRef(i));
             }
         }
         self.cst.truncate(state.truncation_mark.clone());
@@ -553,8 +556,7 @@ impl<'a> Parser<'a> {
             Rule::TokenList => self.create_node_token_list(node_ref, diags),
         }
     }
-    #[allow(clippy::ptr_arg)]
-    fn delete_node(&mut self, _rule: Rule, _node_ref: NodeRef, _diags: &mut Vec<Diagnostic>) {}
+    fn delete_node(&mut self, _rule: Rule, _node_ref: NodeRef) {}
     /// Returns the CST for a parse with the given `source` file and writes diagnostics to `diags`.
     ///
     /// The context can be explicitly defined for the parse.

--- a/src/frontend/sema.rs
+++ b/src/frontend/sema.rs
@@ -136,7 +136,7 @@ pub struct SemanticData<'a> {
     pub predicates: BTreeMap<NodeRef, (&'a str, &'a str)>,
     pub actions: BTreeMap<NodeRef, (&'a str, &'a str)>,
     pub assertions: BTreeMap<NodeRef, (&'a str, &'a str)>,
-    pub rule_bindings: BTreeSet<&'a str>,
+    pub rule_bindings: BTreeMap<&'a str, Vec<NodeRef>>,
     pub first_sets: HashMap<NodeRef, BTreeSet<TokenName<'a>>>,
     pub follow_sets: HashMap<NodeRef, BTreeSet<TokenName<'a>>>,
     pub predict_sets: HashMap<NodeRef, BTreeSet<TokenName<'a>>>,
@@ -486,7 +486,10 @@ impl<'a> GeneralCheck<'a> {
                             diags.push(Diagnostic::uppercase_rule(&name_span, name));
                         }
                         sema.has_rule_rename.insert(rule);
-                        sema.rule_bindings.insert(name);
+                        sema.rule_bindings
+                            .entry(name)
+                            .and_modify(|val| val.push(regex.syntax()))
+                            .or_insert(vec![regex.syntax()]);
                     } else {
                         diags.push(Diagnostic::missing_node_name(&name_span));
                     }
@@ -501,7 +504,10 @@ impl<'a> GeneralCheck<'a> {
                         if name.starts_with(|c: char| c.is_uppercase()) {
                             diags.push(Diagnostic::uppercase_rule(&regex.span(cst), name));
                         }
-                        sema.rule_bindings.insert(name);
+                        sema.rule_bindings
+                            .entry(name)
+                            .and_modify(|val| val.push(regex.syntax()))
+                            .or_insert(vec![regex.syntax()]);
                     }
                 }
                 if regex.whole_rule(cst) {

--- a/src/skeleton/generated.rs
+++ b/src/skeleton/generated.rs
@@ -340,6 +340,7 @@ struct ParserState {{
     pos: usize,
     current: Token,
     truncation_mark: MarkTruncation,
+    diag_count: usize,
 }}
 pub struct Parser<'a> {{
     cst: Cst<'a>,
@@ -438,19 +439,21 @@ impl<'a> Parser<'a> {{
             .get(self.pos)
             .map_or(self.max_offset..self.max_offset, |span| span.clone())
     }}
-    fn get_state(&self) -> ParserState {{
+    fn get_state(&self, diags: &[Diagnostic]) -> ParserState {{
         ParserState {{
             pos: self.pos,
             current: self.current,
             truncation_mark: self.cst.mark_truncation(),
+            diag_count: diags.len(),
         }}
     }}
     fn set_state(&mut self, state: &ParserState, diags: &mut Vec<Diagnostic>) {{
         self.pos = state.pos;
         self.current = state.current;
+        diags.truncate(state.diag_count);
         for i in state.truncation_mark.node_count..self.cst.nodes.len() {{
             if let Node::Rule(rule, _) = self.cst.nodes[i] {{
-                self.delete_node(rule, NodeRef(i), diags);
+                self.delete_node(rule, NodeRef(i));
             }}
         }}
         self.cst.truncate(state.truncation_mark.clone());
@@ -459,8 +462,7 @@ impl<'a> Parser<'a> {{
         match rule {{{4}
         }}
     }}
-    #[allow(clippy::ptr_arg)]
-    fn delete_node(&mut self, _rule: Rule, _node_ref: NodeRef, _diags: &mut Vec<Diagnostic>) {{
+    fn delete_node(&mut self, _rule: Rule, _node_ref: NodeRef) {{
         {5}
     }}
     /// Returns the CST for a parse with the given `source` file and writes diagnostics to `diags`.

--- a/src/skeleton/generated.rs
+++ b/src/skeleton/generated.rs
@@ -37,8 +37,7 @@ macro_rules! err {{
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[allow(dead_code)]
-pub enum Rule {{
-    Error,{0}
+pub enum Rule {{{0}
 }}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
@@ -309,8 +308,7 @@ impl std::fmt::Display for Cst<'_> {{
 }}
 impl std::fmt::Debug for Rule {{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{
-        match self {{
-            Rule::Error => write!(f, "error"),{3}
+        match self {{{3}
         }}
     }}
 }}
@@ -415,7 +413,8 @@ impl<'a> Parser<'a> {{
         self.error(diags, diag);
         self.error_cooldown = true;
         self.advance(true);
-        self.close(m, Rule::Error, diags);
+        self.cst.close(m, Rule::Error);
+        self.create_node_error(NodeRef(m.0), diags);
     }}
     fn peek(&self, lookahead: usize) -> Token {{
         self.tokens
@@ -439,11 +438,6 @@ impl<'a> Parser<'a> {{
             .get(self.pos)
             .map_or(self.max_offset..self.max_offset, |span| span.clone())
     }}
-    fn close(&mut self, mark: MarkOpened, rule: Rule, diags: &mut Vec<Diagnostic>) -> MarkClosed {{
-        let m = self.cst.close(mark, rule);
-        self.create_node(rule, NodeRef(m.0), diags);
-        m
-    }}
     fn get_state(&self) -> ParserState {{
         ParserState {{
             pos: self.pos,
@@ -451,10 +445,23 @@ impl<'a> Parser<'a> {{
             truncation_mark: self.cst.mark_truncation(),
         }}
     }}
-    fn set_state(&mut self, state: &ParserState) {{
+    fn set_state(&mut self, state: &ParserState, diags: &mut Vec<Diagnostic>) {{
         self.pos = state.pos;
         self.current = state.current;
+        for i in state.truncation_mark.node_count..self.cst.nodes.len() {{
+            if let Node::Rule(rule, _) = self.cst.nodes[i] {{
+                self.delete_node(rule, NodeRef(i), diags);
+            }}
+        }}
         self.cst.truncate(state.truncation_mark.clone());
+    }}
+    fn create_node(&mut self, rule: Rule, node_ref: NodeRef, diags: &mut Vec<Diagnostic>) {{
+        match rule {{{4}
+        }}
+    }}
+    #[allow(clippy::ptr_arg)]
+    fn delete_node(&mut self, _rule: Rule, _node_ref: NodeRef, _diags: &mut Vec<Diagnostic>) {{
+        {5}
     }}
     /// Returns the CST for a parse with the given `source` file and writes diagnostics to `diags`.
     ///


### PR DESCRIPTION
The `ParserCallbacks` trait now contains a separate node creation method for each rule.

Furthermore, for each node that may be deleted during backtracking in an ordered choice, there is now a deletion method. These deletion methods are called in reverse order of the corresponding creation methods. This allows to reverse any custom side effects of the node creation methods.