### PR TITLE
Add support for multiple start rules

### DIFF
--- a/src/frontend/diag.rs
+++ b/src/frontend/diag.rs
@@ -32,8 +32,6 @@ pub const MISSING_NODE_NAME: &str = "E027";
 pub const NESTED_ORDERED_CHOICE: &str = "E028";
 pub const ACTION_IN_ORDERED_CHOICE: &str = "E029";
 pub const RETURN_IN_START_RULE: &str = "E030";
-pub const MULTIPLE_START_RULES: &str = "E031";
-
 pub const UNUSED_RULE: &str = "W001";
 pub const UNUSED_TOKEN: &str = "W002";
 pub const UNUSED_OPEN_NODE: &str = "W003";
@@ -80,7 +78,6 @@ pub trait LanguageErrors {
     fn replaceable_ordered_choice(span: &Span) -> Self;
     fn action_in_ordered_choice(span: &Span) -> Self;
     fn return_in_start_rule(span: &Span) -> Self;
-    fn multiple_start_rules(span: &Span, old_span: &Span) -> Self;
 }
 
 impl LanguageErrors for Diagnostic {
@@ -424,18 +421,5 @@ impl LanguageErrors for Diagnostic {
             .with_code(RETURN_IN_START_RULE)
             .with_message("return is not allowed in start rule")
             .with_labels(vec![Label::primary((), span.clone())])
-    }
-
-    fn multiple_start_rules(span: &Span, old_span: &Span) -> Self {
-        Diagnostic::error()
-            .with_code(MULTIPLE_START_RULES)
-            .with_message("multiple start rules defined")
-            .with_labels(vec![
-                Label::primary((), span.clone()),
-                Label::secondary((), old_span.clone()).with_message("previous definition"),
-            ])
-            .with_notes(vec![
-                "note: a grammar must have exactly one start rule".to_string(),
-            ])
     }
 }

--- a/src/skeleton/generated.rs
+++ b/src/skeleton/generated.rs
@@ -324,7 +324,7 @@ impl std::fmt::Display for Cst<'_> {{
 }}
 impl std::fmt::Debug for Rule {{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{
-        match self {{{3}
+        match self {{{2}
         }}
     }}
 }}
@@ -487,23 +487,20 @@ impl<'a> Parser<'a> {{
         self.cst.truncate(state.truncation_mark.clone());
     }}
     fn create_node(&mut self, rule: Rule, node_ref: NodeRef, diags: &mut Vec<Diagnostic>) {{
-        match rule {{{4}
+        match rule {{{3}
         }}
     }}
     fn delete_node(&mut self, _rule: Rule, _node_ref: NodeRef) {{
-        {5}
+        {4}
     }}
-    /// Returns the CST for a parse with the given `source` file and writes diagnostics to `diags`.
-    ///
-    /// The context can be explicitly defined for the parse.
-    pub fn parse_with_context(
+    fn new(
         source: &'a str,
         diags: &mut Vec<Diagnostic>,
         context: Context<'a>,
-    ) -> Cst<'a> {{
+    ) -> Parser<'a> {{
         let (tokens, spans) = Self::create_tokens(source, diags);
         let max_offset = source.len();
-        let mut parser = Self {{
+        Self {{
             current: Token::EOF,
             cst: Cst::new(source, spans),
             tokens,
@@ -513,16 +510,5 @@ impl<'a> Parser<'a> {{
             context,
             error_cooldown: false,
             in_ordered_choice: false,
-        }};
-        parser.rule_{2}(diags);
-        parser.cst
-    }}
-    /// Returns the CST for a parse with the given `source` file and writes diagnostics to `diags`.
-    ///
-    /// The context will be default initialized for the parse.
-    pub fn parse(
-        source: &'a str,
-        diags: &mut Vec<Diagnostic>,
-    ) -> Cst<'a> {{
-        Self::parse_with_context(source, diags, Context::default())
+        }}
     }}

--- a/tests/frontend.rs
+++ b/tests/frontend.rs
@@ -215,8 +215,6 @@ fn multiple_start() {
     let diags = gen_diags("tests/frontend/multiple_start.llw");
     let mut lines = diags.lines();
 
-    assert_eq!(lines.next(), Some("tests/frontend/multiple_start.llw:4:1: error[E031]: multiple start rules defined"));
-    assert_eq!(lines.next(), Some("tests/frontend/multiple_start.llw:5:1: error[E031]: multiple start rules defined"));
     assert_eq!(lines.next(), None);
 }
 


### PR DESCRIPTION
Fix #39 Lelwel now allows for multiple `start foo; start bar; start nya;` statements.
It outputs a `parse` function for the first start rule, and a `parse_rule_name_goes_here` function for all subsequent rules.

This should keep lelwel's behaviour unchanged for a single start rule.

However, I'm not sure how to check that lelwel's behaviour remains correct when introducing multiple start rules. Advice would be appreciated.

This is also missing the documentation in the Readme.