### PR TITLE
Make `Diagnostic` and `Context` associated types

### DIFF
--- a/examples/brainfuck/src/parser.rs
+++ b/examples/brainfuck/src/parser.rs
@@ -3,14 +3,12 @@ use codespan_reporting::diagnostic::Label;
 
 pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<()>;
 
-#[derive(Default)]
-pub struct Context<'a> {
-    marker: std::marker::PhantomData<&'a ()>,
-}
-
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-impl<'a> ParserCallbacks for Parser<'a> {
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = ();
+
     fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }

--- a/examples/c/src/parser.rs
+++ b/examples/c/src/parser.rs
@@ -143,7 +143,10 @@ impl Parser<'_> {
 }
 
 #[allow(clippy::ptr_arg)]
-impl ParserCallbacks for Parser<'_> {
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = Context<'a>;
+
     fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }

--- a/examples/calc/src/parser.rs
+++ b/examples/calc/src/parser.rs
@@ -3,14 +3,12 @@ use codespan_reporting::diagnostic::Label;
 
 pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<()>;
 
-#[derive(Default)]
-pub struct Context<'a> {
-    marker: std::marker::PhantomData<&'a ()>,
-}
-
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-impl ParserCallbacks for Parser<'_> {
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = ();
+
     fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }

--- a/examples/json/src/parser.rs
+++ b/examples/json/src/parser.rs
@@ -4,14 +4,12 @@ use crate::lexer::{Token, tokenize};
 
 pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<()>;
 
-#[derive(Default)]
-pub struct Context<'a> {
-    marker: std::marker::PhantomData<&'a ()>,
-}
-
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-impl ParserCallbacks for Parser<'_> {
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = ();
+
     fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }

--- a/examples/l/src/parser.rs
+++ b/examples/l/src/parser.rs
@@ -3,12 +3,12 @@ use codespan_reporting::diagnostic::Label;
 
 pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<()>;
 
-#[derive(Default)]
-pub struct Context<'a> {
-    marker: std::marker::PhantomData<&'a ()>,
-}
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-impl ParserCallbacks for Parser<'_> {
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = ();
+
     fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
@@ -24,5 +24,3 @@ impl ParserCallbacks for Parser<'_> {
         self.peek(1) != Token::RPar
     }
 }
-
-include!(concat!(env!("OUT_DIR"), "/generated.rs"));

--- a/examples/lua/src/parser.rs
+++ b/examples/lua/src/parser.rs
@@ -4,14 +4,12 @@ use codespan_reporting::diagnostic::Label;
 
 pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<()>;
 
-#[derive(Default)]
-pub struct Context<'a> {
-    marker: std::marker::PhantomData<&'a ()>,
-}
-
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-impl ParserCallbacks for Parser<'_> {
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = ();
+
     fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }

--- a/examples/oberon0/src/parser.rs
+++ b/examples/oberon0/src/parser.rs
@@ -3,14 +3,12 @@ use codespan_reporting::diagnostic::Label;
 
 pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<()>;
 
-#[derive(Default)]
-pub struct Context<'a> {
-    marker: std::marker::PhantomData<&'a ()>,
-}
-
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-impl ParserCallbacks for Parser<'_> {
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = ();
+
     fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }

--- a/examples/python2/src/parser.rs
+++ b/examples/python2/src/parser.rs
@@ -3,14 +3,12 @@ use codespan_reporting::diagnostic::Label;
 
 pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<()>;
 
-#[derive(Default)]
-pub struct Context<'a> {
-    marker: std::marker::PhantomData<&'a ()>,
-}
-
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-impl ParserCallbacks for Parser<'_> {
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = ();
+
     fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }

--- a/examples/toml/src/parser.rs
+++ b/examples/toml/src/parser.rs
@@ -3,11 +3,6 @@ use codespan_reporting::diagnostic::Label;
 
 pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<()>;
 
-#[derive(Default)]
-pub struct Context<'a> {
-    marker: std::marker::PhantomData<&'a ()>,
-}
-
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
 impl Parser<'_> {
@@ -19,7 +14,10 @@ impl Parser<'_> {
     }
 }
 
-impl<'a> ParserCallbacks for Parser<'a> {
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = ();
+
     fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }

--- a/examples/wgsl/src/parser.rs
+++ b/examples/wgsl/src/parser.rs
@@ -104,7 +104,10 @@ impl Parser<'_> {
     }
 }
 
-impl<'a> ParserCallbacks for Parser<'a> {
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = Context<'a>;
+
     fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -3,18 +3,19 @@ use codespan_reporting::diagnostic::Label;
 
 pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<()>;
 
-#[derive(Default)]
-pub struct Context<'a> {
-    marker: std::marker::PhantomData<&'a ()>,
-}
-
 include!("./generated.rs");
 
-impl ParserCallbacks for Parser<'_> {
-    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = ();
+
+    fn create_tokens(
+        source: &'a str,
+        diags: &mut Vec<Self::Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
-    fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {
+    fn create_diagnostic(&self, span: Span, message: String) -> Self::Diagnostic {
         Diagnostic::error()
             .with_message(message)
             .with_labels(vec![Label::primary((), span)])

--- a/src/skeleton/parser.rs
+++ b/src/skeleton/parser.rs
@@ -1,14 +1,8 @@
 use super::lexer::{Token, tokenize};
+
+// TODO: change if codespan_reporting is not used
 use codespan_reporting::diagnostic::Label;
-
-// TODO: change definition and all uses if codespan_reporting is not used
 pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<()>;
-
-// TODO: add context information to the parser if required
-#[derive(Default)]
-pub struct Context<'a> {
-    marker: std::marker::PhantomData<&'a ()>
-}
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 


### PR DESCRIPTION
This makes it possible to use diagnostic types with a lifetime parameter, such as the one provided by [annotate-snippets-rs](https://github.com/rust-lang/annotate-snippets-rs).

This is a breaking change:
- Add the lifetime parameter at the implementation of `ParserCallbacks`.
- Define the associated `Context` and `Diagnostic` types in the implementation of `ParserCallbacks`.