### PR TITLE
Allow lexer to update parser context

### DIFF
--- a/examples/brainfuck/src/parser.rs
+++ b/examples/brainfuck/src/parser.rs
@@ -9,7 +9,11 @@ impl<'a> ParserCallbacks<'a> for Parser<'a> {
     type Diagnostic = Diagnostic;
     type Context = ();
 
-    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+    fn create_tokens(
+        _context: &mut Self::Context,
+        source: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
     fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {

--- a/examples/c/src/parser.rs
+++ b/examples/c/src/parser.rs
@@ -147,7 +147,11 @@ impl<'a> ParserCallbacks<'a> for Parser<'a> {
     type Diagnostic = Diagnostic;
     type Context = Context<'a>;
 
-    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+    fn create_tokens(
+        _context: &mut Self::Context,
+        source: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
     fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {

--- a/examples/calc/src/parser.rs
+++ b/examples/calc/src/parser.rs
@@ -9,7 +9,11 @@ impl<'a> ParserCallbacks<'a> for Parser<'a> {
     type Diagnostic = Diagnostic;
     type Context = ();
 
-    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+    fn create_tokens(
+        _context: &mut Self::Context,
+        source: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
     fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {

--- a/examples/json/src/parser.rs
+++ b/examples/json/src/parser.rs
@@ -10,7 +10,11 @@ impl<'a> ParserCallbacks<'a> for Parser<'a> {
     type Diagnostic = Diagnostic;
     type Context = ();
 
-    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+    fn create_tokens(
+        _context: &mut Self::Context,
+        source: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
     fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {

--- a/examples/l/src/parser.rs
+++ b/examples/l/src/parser.rs
@@ -9,7 +9,11 @@ impl<'a> ParserCallbacks<'a> for Parser<'a> {
     type Diagnostic = Diagnostic;
     type Context = ();
 
-    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+    fn create_tokens(
+        _context: &mut Self::Context,
+        source: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
     fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {

--- a/examples/lua/src/parser.rs
+++ b/examples/lua/src/parser.rs
@@ -10,7 +10,11 @@ impl<'a> ParserCallbacks<'a> for Parser<'a> {
     type Diagnostic = Diagnostic;
     type Context = ();
 
-    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+    fn create_tokens(
+        _context: &mut Self::Context,
+        source: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
     fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {

--- a/examples/oberon0/src/parser.rs
+++ b/examples/oberon0/src/parser.rs
@@ -9,7 +9,11 @@ impl<'a> ParserCallbacks<'a> for Parser<'a> {
     type Diagnostic = Diagnostic;
     type Context = ();
 
-    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+    fn create_tokens(
+        _context: &mut Self::Context,
+        source: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
     fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {

--- a/examples/python2/src/parser.rs
+++ b/examples/python2/src/parser.rs
@@ -9,7 +9,11 @@ impl<'a> ParserCallbacks<'a> for Parser<'a> {
     type Diagnostic = Diagnostic;
     type Context = ();
 
-    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+    fn create_tokens(
+        _context: &mut Self::Context,
+        source: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
     fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {

--- a/examples/toml/src/parser.rs
+++ b/examples/toml/src/parser.rs
@@ -18,7 +18,11 @@ impl<'a> ParserCallbacks<'a> for Parser<'a> {
     type Diagnostic = Diagnostic;
     type Context = ();
 
-    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+    fn create_tokens(
+        _context: &mut Self::Context,
+        source: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
     fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {

--- a/examples/wgsl/src/parser.rs
+++ b/examples/wgsl/src/parser.rs
@@ -108,7 +108,11 @@ impl<'a> ParserCallbacks<'a> for Parser<'a> {
     type Diagnostic = Diagnostic;
     type Context = Context<'a>;
 
-    fn create_tokens(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+    fn create_tokens(
+        _context: &mut Self::Context,
+        source: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
         tokenize(source, diags)
     }
     fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {

--- a/src/backend/rust.rs
+++ b/src/backend/rust.rs
@@ -151,7 +151,7 @@ impl RustOutput {
             \n    type Context: Default;\
             \n\
             \n    /// Called at the start of the parse to generate all tokens and corresponding spans.\
-            \n    fn create_tokens(source: &'a str, diags: &mut Vec<Self::Diagnostic>) -> (Vec<Token>, Vec<Span>);\
+            \n    fn create_tokens(context: &mut Self::Context, source: &'a str, diags: &mut Vec<Self::Diagnostic>) -> (Vec<Token>, Vec<Span>);\
             \n    /// Called when diagnostic is created.\
             \n    fn create_diagnostic(&self, span: Span, message: String) -> Self::Diagnostic;\
             \n    /// This predicate can be used to skip normal tokens.\
@@ -163,7 +163,7 @@ impl RustOutput {
             \n    type Diagnostic = Diagnostic;\
             \n    type Context = (); // TODO: add context information to the parser if required\
             \n\
-            \n    fn create_tokens(source: &'a str, diags: &mut Vec<Self::Diagnostic>) -> (Vec<Token>, Vec<Span>) {\
+            \n    fn create_tokens(_context: &mut Self::Context, source: &'a str, diags: &mut Vec<Self::Diagnostic>) -> (Vec<Token>, Vec<Span>) {\
             \n        tokenize(source, diags)\
             \n    }\
             \n    fn create_diagnostic(&self, span: Span, message: String) -> Self::Diagnostic> {\

--- a/src/frontend/generated.rs
+++ b/src/frontend/generated.rs
@@ -633,9 +633,9 @@ impl<'a> Parser<'a> {
     pub fn new_with_context(
         source: &'a str,
         diags: &mut Vec<<Self as ParserCallbacks<'a>>::Diagnostic>,
-        context: <Self as ParserCallbacks<'a>>::Context,
+        mut context: <Self as ParserCallbacks<'a>>::Context,
     ) -> Parser<'a> {
-        let (tokens, spans) = Self::create_tokens(source, diags);
+        let (tokens, spans) = Self::create_tokens(&mut context, source, diags);
         let max_offset = source.len();
         Self {
             current: Token::EOF,
@@ -1569,8 +1569,11 @@ pub trait ParserCallbacks<'a> {
     type Context: Default;
 
     /// Called at the start of the parse to generate all tokens and corresponding spans.
-    fn create_tokens(source: &'a str, diags: &mut Vec<Self::Diagnostic>)
-        -> (Vec<Token>, Vec<Span>);
+    fn create_tokens(
+        context: &mut Self::Context,
+        source: &'a str,
+        diags: &mut Vec<Self::Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>);
     /// Called when diagnostic is created.
     fn create_diagnostic(&self, span: Span, message: String) -> Self::Diagnostic;
     /// This predicate can be used to skip normal tokens.

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -10,6 +10,7 @@ impl<'a> ParserCallbacks<'a> for Parser<'a> {
     type Context = ();
 
     fn create_tokens(
+        _context: &mut Self::Context,
         source: &'a str,
         diags: &mut Vec<Self::Diagnostic>,
     ) -> (Vec<Token>, Vec<Span>) {

--- a/src/skeleton/generated.rs
+++ b/src/skeleton/generated.rs
@@ -531,9 +531,9 @@ impl<'a> Parser<'a> {{
     pub fn new_with_context(
         source: &'a str,
         diags: &mut Vec<<Self as ParserCallbacks<'a>>::Diagnostic>,
-        context: <Self as ParserCallbacks<'a>>::Context,
+        mut context: <Self as ParserCallbacks<'a>>::Context,
     ) -> Parser<'a> {{
-        let (tokens, spans) = Self::create_tokens(source, diags);
+        let (tokens, spans) = Self::create_tokens(&mut context, source, diags);
         let max_offset = source.len();
         Self {{
             current: Token::EOF,


### PR DESCRIPTION
This is a breaking change:
- Add the `_context: &mut Self::Context` parameter to the implementation of `create_tokens`.