### PR TITLE
Remove `Default` bound from `Context`

### DIFF
--- a/src/backend/rust.rs
+++ b/src/backend/rust.rs
@@ -148,7 +148,7 @@ impl RustOutput {
             b"#[allow(clippy::ptr_arg)]\
             \npub trait ParserCallbacks<'a> {\
             \n    type Diagnostic;\
-            \n    type Context: Default;\
+            \n    type Context;\
             \n\
             \n    /// Called at the start of the parse to generate all tokens and corresponding spans.\
             \n    fn create_tokens(context: &mut Self::Context, source: &'a str, diags: &mut Vec<Self::Diagnostic>) -> (Vec<Token>, Vec<Span>);\

--- a/src/frontend/generated.rs
+++ b/src/frontend/generated.rs
@@ -683,7 +683,10 @@ impl<'a> Parser<'a> {
     pub fn new(
         source: &'a str,
         diags: &mut Vec<<Self as ParserCallbacks<'a>>::Diagnostic>,
-    ) -> Parser<'a> {
+    ) -> Parser<'a>
+    where
+        <Self as ParserCallbacks<'a>>::Context: Default,
+    {
         #[allow(clippy::unit_arg)]
         Self::new_with_context(
             source,
@@ -1596,7 +1599,7 @@ impl<'a> Parser<'a> {
 #[allow(clippy::ptr_arg)]
 pub trait ParserCallbacks<'a> {
     type Diagnostic;
-    type Context: Default;
+    type Context;
 
     /// Called at the start of the parse to generate all tokens and corresponding spans.
     fn create_tokens(

--- a/src/skeleton/generated.rs
+++ b/src/skeleton/generated.rs
@@ -579,7 +579,10 @@ impl<'a> Parser<'a> {{
     pub fn new(
         source: &'a str,
         diags: &mut Vec<<Self as ParserCallbacks<'a>>::Diagnostic>,
-    ) -> Parser<'a> {{
+    ) -> Parser<'a>
+    where
+        <Self as ParserCallbacks<'a>>::Context: Default,
+    {{
         #[allow(clippy::unit_arg)]
         Self::new_with_context(source, diags, <Self as ParserCallbacks<'a>>::Context::default())
     }}


### PR DESCRIPTION
I changed only 2 things:

1. Remove `: Default` bound from `type Context` in `trait ParserCallbacks<'a>`
2. Add `where <Self as ParserCallbacks<'a>>::Context: Default` for `Parser::new()` method

This should allow users to use `Context` types that don't/can't implement `Default` while still providing `Parser::new()` without breaking changes. I think.

At least `cargo clippy` and `cargo test` with `--workspace` flag were clean. Please feel free to let me know if there's anything else I should do to make sure this doesn't break anything.

(Edit) I also tried changing the `Default` impl of `Context` in the C example to a plain method `pub fn new()`. Things seem to work as intended with a compile error on `Parser::new()` and no errors or warnings with `Parser::new_with_context()`.